### PR TITLE
Remove the "BuildVignettes: no" from the DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,5 +24,4 @@ Suggests:
     roxygen2,
     testthat
 VignetteBuilder: knitr
-BuildVignettes: no
 LazyData: true


### PR DESCRIPTION
I couldn't figure out the business about `"no prebuilt vignette index"` so I gave up on the prebuilt vignette.
