### PR TITLE
can_arxiv_connect: allow "Success" as well as "success"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aRxiv
 Title: Interface to the arXiv API
-Version: 0.5.13
-Date: 2015-11-08
+Version: 0.5.14
+Date: 2016-01-14
 Authors@R: c(person("Karthik", "Ram", role="aut",
     email="karthik.ram@gmail.com"),
     person("Karl", "Broman", rol=c("aut","cre"),
@@ -26,4 +26,4 @@ Suggests:
     testthat
 VignetteBuilder: knitr
 LazyData: true
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/R/can_arxiv_connect.R
+++ b/R/can_arxiv_connect.R
@@ -39,7 +39,7 @@ can_arxiv_connect <-
 
     # check for general http error
     status <- httr::http_status(z)
-    if(status$category != "success") {
+    if(status$category != "success" && status$category != "Success") {
         httr::warn_for_status(z)
         return(FALSE)
     }


### PR DESCRIPTION
In `can_arxiv_connect()`, it seems like the `httr::http_status()` category can be `"Success"` and not just `"success"`.