### PR TITLE
Trap empty search queries; don't send them to arXiv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aRxiv
 Title: Interface to the arXiv API
-Version: 0.5.15
-Date: 2017-04-05
+Version: 0.5.16
+Date: 2017-04-28
 Authors@R: c(person("Karthik", "Ram", role="aut",
     email="karthik.ram@gmail.com"),
     person("Karl", "Broman", rol=c("aut","cre"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+aRxiv 0.5.16
+------------
+
+BUG FIXES
+
+* To eliminate continued pain over empty search queries, just trap
+  them in advance and don't send them to arXiv.
+
+
 aRxiv 0.5.15
 ------------
 

--- a/R/arxiv_count.R
+++ b/R/arxiv_count.R
@@ -40,6 +40,8 @@ function(query=NULL, id_list=NULL)
     query <- paste_query(query)
     id_list <- paste_id_list(id_list)
 
+    if(is_blank(query) && is_blank(id_list)) return(0)
+
     delay_if_necessary()
     # do search
     # (extra messy to avoid possible problems when testing on CRAN

--- a/R/arxiv_search.R
+++ b/R/arxiv_search.R
@@ -98,6 +98,8 @@ function(query=NULL, id_list=NULL, start=0, limit=10,
     query <- paste_query(query)
     id_list <- paste_id_list(id_list)
 
+    if(is_blank(query) && is_blank(id_list)) return(empty_result())
+
     sort_by <- match.arg(sort_by)
     sort_order <- ifelse(ascending, "ascending", "descending")
     output_format <- match.arg(output_format)

--- a/R/is_blank.R
+++ b/R/is_blank.R
@@ -1,0 +1,9 @@
+# check if query is NULL or white space
+is_blank <-
+    function(query)
+{
+    if(is.null(query) || grepl("^\\s*$", query)) # white space
+        return(TRUE)
+
+    FALSE
+}


### PR DESCRIPTION
To fix the repeated sporadic errors (see Issue #41), we now just trap empty searches before sending them to arXiv. Should have done this in the first place. 