### PR TITLE
Put link to CONDUCT.md in inst/; add primary one to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@ inst/scripts/.RData
 appveyor.yml
 \.Rout$
 inst/ToDo\.html
+^CONDUCT.md$

--- a/inst/CONDUCT.md
+++ b/inst/CONDUCT.md
@@ -1,0 +1,1 @@
+../CONDUCT.md


### PR DESCRIPTION
 - This is to avoid a note about "Non-standard file/directory found at top level"