### PR TITLE
New version to CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@ inst/scripts/.RData
 inst/ToDo\.html
 ^CONDUCT.md$
 ^\.github$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aRxiv
 Title: Interface to the arXiv API
-Version: 0.9.2
-Date: 2024-02-02
+Version: 0.10
+Date: 2024-02-29
 Authors@R: c(person("Karthik", "Ram", role="aut",
     email="karthik.ram@gmail.com", comment=c(ORCID = "0000-0002-0233-1757")),
     person("Karl", "Broman", role=c("aut","cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aRxiv
 Title: Interface to the arXiv API
-Version: 0.9.1
-Date: 2024-01-22
+Version: 0.9.2
+Date: 2024-02-02
 Authors@R: c(person("Karthik", "Ram", role="aut",
     email="karthik.ram@gmail.com", comment=c(ORCID = "0000-0002-0233-1757")),
     person("Karl", "Broman", role=c("aut","cre"),
@@ -28,5 +28,5 @@ Suggests:
 VignetteBuilder: knitr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2014-2017
+YEAR: 2014-2024
 COPYRIGHT HOLDER: Karthik Ram and Karl W Broman

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+### The MIT License (MIT)
+
+Copyright (c) 2014-2024 Karthik Ram and Karl W Broman
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
-aRxiv 0.9.1
+aRxiv 0.9.2
 -----------
+
+### MINOR CHANGES
+
+* Update vignette due to previous change in the format of the
+  arxiv_cats dataset.
 
 ### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,5 @@
-aRxiv 0.9.2
------------
-
-### MINOR CHANGES
-
-* Update vignette due to previous change in the format of the
-  arxiv_cats dataset.
+aRxiv 0.10
+----------
 
 ### BUG FIXES
 

--- a/inst/doc/aRxiv.html
+++ b/inst/doc/aRxiv.html
@@ -467,19 +467,19 @@ actual query. Multiple queries can be combined with <code>AND</code>,
 <code>OR</code>, and <code>ANDNOT</code>. The default is
 <code>OR</code>.</p>
 <div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;au:Peter au:Hall&#39;</span>)</span></code></pre></div>
-<pre><code>## [1] 37783</code></pre>
+<pre><code>## [1] 37886</code></pre>
 <div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;au:Peter OR au:Hall&#39;</span>)</span></code></pre></div>
-<pre><code>## [1] 37783</code></pre>
+<pre><code>## [1] 37886</code></pre>
 <div class="sourceCode" id="cb22"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb22-1"><a href="#cb22-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;au:Peter AND au:Hall&#39;</span>)</span></code></pre></div>
 <pre><code>## [1] 161</code></pre>
 <div class="sourceCode" id="cb24"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb24-1"><a href="#cb24-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;au:Hall ANDNOT au:Peter&#39;</span>)</span></code></pre></div>
-<pre><code>## [1] 2745</code></pre>
+<pre><code>## [1] 2749</code></pre>
 <p>It appears that in the author field (and many other fields) you must
 search full words, and that wild cards are not allowed.</p>
 <div class="sourceCode" id="cb26"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb26-1"><a href="#cb26-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;au:P* AND au:Hall&#39;</span>)</span></code></pre></div>
 <pre><code>## [1] 0</code></pre>
 <div class="sourceCode" id="cb28"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb28-1"><a href="#cb28-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;au:P AND au:Hall&#39;</span>)</span></code></pre></div>
-<pre><code>## [1] 1231</code></pre>
+<pre><code>## [1] 1232</code></pre>
 <div class="sourceCode" id="cb30"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb30-1"><a href="#cb30-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;au:&quot;P Hall&quot;&#39;</span>)</span></code></pre></div>
 <pre><code>## [1] 44</code></pre>
 </div>
@@ -506,9 +506,9 @@ or use the <code>*</code> wildcard.</p>
 <div class="sourceCode" id="cb36"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb36-1"><a href="#cb36-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;cat:stat&#39;</span>)</span></code></pre></div>
 <pre><code>## [1] 0</code></pre>
 <div class="sourceCode" id="cb38"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb38-1"><a href="#cb38-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;cat:stat.AP&#39;</span>)</span></code></pre></div>
-<pre><code>## [1] 17577</code></pre>
+<pre><code>## [1] 17664</code></pre>
 <div class="sourceCode" id="cb40"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb40-1"><a href="#cb40-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&#39;cat:stat*&#39;</span>)</span></code></pre></div>
-<pre><code>## [1] 114647</code></pre>
+<pre><code>## [1] 115092</code></pre>
 </div>
 <div id="dates-and-ranges-of-dates" class="section level3">
 <h3>Dates and ranges of dates</h3>
@@ -556,14 +556,14 @@ items, separated by a vertical bar (<code>|</code>).</li>
 (<code>&quot;&quot;</code>).</li>
 <li>The <code>categories</code> column may contain not just the aRxiv
 categories (e.g., <code>stat.AP</code>) but also codes for the <a href="https://mathscinet.ams.org/mathscinet/msc/msc2010.html">Mathematical
-Subject Classification (MSC)</a> (e.g., 14J60) and the <a href="https://www.acm.org/about/class/1998/">ACM Computing
+Subject Classification (MSC)</a> (e.g., 14J60) and the <a href="https://www.acm.org/publications/class-2012">ACM Computing
 Classification System</a> (e.g., F.2.2). These are not searchable with
 <code>cat:</code> but are searchable with a general search.</li>
 </ul>
 <div class="sourceCode" id="cb50"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb50-1"><a href="#cb50-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&quot;cat:14J60&quot;</span>)</span></code></pre></div>
 <pre><code>## [1] 0</code></pre>
 <div class="sourceCode" id="cb52"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb52-1"><a href="#cb52-1" tabindex="-1"></a><span class="fu">arxiv_count</span>(<span class="st">&quot;14J60&quot;</span>)</span></code></pre></div>
-<pre><code>## [1] 870</code></pre>
+<pre><code>## [1] 874</code></pre>
 </div>
 <div id="sorting-results" class="section level2">
 <h2>Sorting results</h2>

--- a/vignettes/aRxiv.Rmd
+++ b/vignettes/aRxiv.Rmd
@@ -263,7 +263,7 @@ A few short notes:
   (e.g., `stat.AP`) but also codes for the
   [Mathematical Subject Classification (MSC)](https://mathscinet.ams.org/mathscinet/msc/msc2010.html) (e.g., 14J60)
   and the
-  [ACM Computing Classification System](https://www.acm.org/about/class/1998/)
+  [ACM Computing Classification System](https://www.acm.org/publications/class-2012)
   (e.g., F.2.2). These are not searchable with `cat:` but are
   searchable with a general search.
 


### PR DESCRIPTION
- Fix a link in the vignette
- Add a LICENSE.md file with the MIT license text
- Version 0.10 now on [CRAN](https://cran.r-project.org/package=aRxiv).